### PR TITLE
Savedocx

### DIFF
--- a/save_doc_as_docx.ps1
+++ b/save_doc_as_docx.ps1
@@ -1,0 +1,49 @@
+# this .ps1 script is a simplification of htmlmaker_preprocessing.ps1
+# it just expects a .doc file as a parameter and saves it as a .docx
+# optional removal of the .doc
+# no built-in logging; that can be more easily captured with open3 or similar whatever invokes this
+
+param([string]$inputFile)
+$docpath = "$($inputFile)x"
+
+$word = New-Object -ComObject word.application
+$word.visible = $true
+
+# Make sure "Store random number..." setting is off
+$word.Options.StoreRSIDOnSave = $false
+Write-Host "Removing revision data"
+
+$doc = $word.documents.open($inputFile)
+
+# turn off track changes, accept all changes and delete all comments
+# have to do here, or we don't solve dumb XML revision problem
+$doc.TrackRevisions = $false
+$doc.Revisions.AcceptAll()
+Foreach($comment in $doc.Comments)
+{
+    $comment.Delete()
+}
+
+# save file as .docx
+# If we didn't make changes we still need to force save, so we can
+# remove any revision data in XML file, so set 'Saved' property to false
+$doc.Saved=$false
+$wdFormatDocx = 16  # wdFormatDocumentDefault is docx, reference number is 16
+
+# Have to add [ref]s for certain versions of powershell (2.0),
+# we'll see which way works on server
+# https://richardspowershellblog.wordpress.com/2012/10/15/powershell-3-and-word/
+# so only use one or the other of these next two lines
+$saved=$doc.Saved
+#$doc.saveas($docpath, $wdFormatDocx)
+$doc.saveas([ref]$docpath, [ref]$wdFormatDocx)
+
+$doc.close()
+$word.Quit()
+$word = $null
+
+# Next line if you want to remove the original .doc file
+Remove-Item ($inputFile)
+
+[gc]::collect()
+[gc]::WaitForPendingFinalizers()

--- a/val_header.rb
+++ b/val_header.rb
@@ -43,6 +43,10 @@ module Val
 		def self.filename_normalized
 			@@filename_normalized
 		end
+    @@filename_docx = "#{@@basename_normalized}.docx"
+		def self.filename_docx
+			@@filename_docx
+		end
 	end
 	class Paths
 		@@testing_value_file = File.join("C:", "staging.txt")
@@ -91,7 +95,7 @@ module Val
 		def self.original_file
 			@@original_file
 		end
-		@@working_file = File.join(Paths.tmp_dir, Doc.filename_normalized)
+		@@working_file = File.join(Paths.tmp_dir, Doc.filename_docx)
 		def self.working_file
 			@@working_file
 		end

--- a/validator_cleanup.rb
+++ b/validator_cleanup.rb
@@ -100,7 +100,7 @@ if status_hash['bookmaker_ready'] && Val::Paths.project_name =~ /egalleymaker/
 		tmp_dir_new = File.join(Val::Paths.working_dir,"#{isbn}_to_bookmaker_#{index}")
 		Mcmlln::Tools.moveFile(Val::Paths.tmp_dir, tmp_dir_new)
 		#update path for working_file
-		working_file_updated = File.join(tmp_dir_new, Val::Doc.filename_normalized)
+		working_file_updated = File.join(tmp_dir_new, Val::Doc.filename_docx)
 		#make a copy of working file and give it a DONE in filename for troubleshooting from this folder
 		#setting up name for done_file: this needs to include working isbn, DONE, and index.  Here we go:
 		if Val::Doc.filename_normalized =~ /9(7(8|9)|-7(8|9)|7-(8|9)|-7-(8|9))[0-9-]{10,14}/
@@ -113,13 +113,13 @@ if status_hash['bookmaker_ready'] && Val::Paths.project_name =~ /egalleymaker/
     		end
   	else
     		logger.info {"adding isbn to done_filename because it was missing"}
-			  done_file = working_file_updated.gsub(/#{Val::Doc.extension}$/,"_#{isbn}#{Val::Doc.extension}")
+			  done_file = working_file_updated.gsub(/.docx$/,"_#{isbn}.docx")
   	end
-  	done_file = done_file.gsub(/#{Val::Doc.extension}$/,"_DONE_#{index}#{Val::Doc.extension}")
+  	done_file = done_file.gsub(/.docx$/,"_DONE_#{index}.docx")
 		Mcmlln::Tools.copyFile(working_file_updated, done_file)
     Mcmlln::Tools.copyFile(done_file, bookmaker_bot_IN)
 		#rename working file to keep it distinct from infile
-		new_workingfile = working_file_updated.gsub(/#{Val::Doc.extension}$/,"_workingfile#{Val::Doc.extension}")
+		new_workingfile = working_file_updated.gsub(/.docx$/,"_workingfile.docx")
 		File.rename(working_file_updated, new_workingfile)
 		#make a copy of infile so we have a reference to it for posts
 	  Mcmlln::Tools.copyFile(Val::Files.original_file, tmp_dir_new)

--- a/validator_tmparchive.rb
+++ b/validator_tmparchive.rb
@@ -22,46 +22,67 @@ user_email = ''
 
 #---------------------  METHODS
 def set_submitter_info(logger,user_email,user_name,contacts_hash,status_hash)
-	if user_email == ''
-	    status_hash['api_ok'] = false
-	    contacts_hash.merge!(submitter_name: 'Workflows')
-	    contacts_hash.merge!(submitter_email: 'workflows@macmillan.com')
-	    logger.info {"dropbox api may have failed, not finding file metadata"}
-	else
-		#check to see if submitter is in ebooks dept.:
-		staff_hash = Mcmlln::Tools.readjson(Val::Files.staff_emails)  		#read in our static pe/pm json
-		for i in 0..staff_hash.length - 1
-				if user_email.downcase == "#{staff_hash[i]['email'].downcase}"
-						if "#{staff_hash[i]['division']}" == 'Ebooks' || "#{staff_hash[i]['division']}" == 'Workflow'
-								contacts_hash['ebooksDept_submitter'] = true
-								logger.info {"#{user_name} is a member of ebooks or Workflow dept, flagging that to edit user comm. addressees"}
-						end
-				end
-		end
+  if user_email == ''
+    status_hash['api_ok'] = false
+    contacts_hash.merge!(submitter_name: 'Workflows')
+    contacts_hash.merge!(submitter_email: 'workflows@macmillan.com')
+    logger.info {"dropbox api may have failed, not finding file metadata"}
+  else
+    #check to see if submitter is in ebooks dept.:
+    staff_hash = Mcmlln::Tools.readjson(Val::Files.staff_emails)  		#read in our static pe/pm json
+    for i in 0..staff_hash.length - 1
+      if user_email.downcase == "#{staff_hash[i]['email'].downcase}"
+        if "#{staff_hash[i]['division']}" == 'Ebooks' || "#{staff_hash[i]['division']}" == 'Workflow'
+          contacts_hash['ebooksDept_submitter'] = true
+          logger.info {"#{user_name} is a member of ebooks or Workflow dept, flagging that to edit user comm. addressees"}
+        end
+      end
+    end
     #writing user info from Dropbox API to json
     contacts_hash.merge!(submitter_name: user_name)
     contacts_hash.merge!(submitter_email: user_email)
     Vldtr::Tools.write_json(contacts_hash,Val::Files.contacts_file)
     logger.info {"file submitter retrieved, display name: \"#{user_name}\", email: \"#{user_email}\", wrote to contacts.json"}
-	end
+  end
 end
 def nondoc(logger,status_hash)
-	status_hash['docfile'] = false
-	logger.info {"This is not a .doc or .docx file. Posting error.txt to the project_dir for user."}
-	File.open(Val::Files.errFile, 'w') { |f|
-			f.puts "Unable to process \"#{Val::Doc.filename_normalized}\". Your document is not a .doc or .docx file."
-	}
+  status_hash['docfile'] = false
+  logger.info {"This is not a .doc or .docx file. Posting error.txt to the project_dir for user."}
+  File.open(Val::Files.errFile, 'w') { |f|
+    f.puts "Unable to process \"#{Val::Doc.filename_normalized}\". Your document is not a .doc or .docx file."
+  }
+end
+def convertDocToDocxPSscript(doc_or_docx_workingfile)
+  # doctodocx = "S:\\resources\\bookmaker_scripts\\bookmaker_addons\\htmlmaker_preprocessing.ps1"
+  # doctodocx = "#{Val::Paths.bookmaker_scripts_dir}\\bookmaker_addons\\htmlmaker_preprocessing.ps1"
+  # `PowerShell -NoProfile -ExecutionPolicy Bypass -Command "#{doctodocx} '#{doc_or_docx_workingfile}'"`
+  `#{Val::Resources.powershell_exe} "#{File.join(Val::Paths.scripts_dir, 'save_doc_as_docx.ps1')} '#{doc_or_docx_workingfile}'"`
+rescue => e
+  puts e
 end
 def movedoc(logger)
-	#if its a .doc(x) lets go ahead and move it to tmpdir, keep a pristing copy in subfolder
-	FileUtils.mkdir_p Val::Paths.tmp_original_dir
-	Mcmlln::Tools.moveFile(Val::Doc.input_file_untag_chars, Val::Files.original_file)
-	Mcmlln::Tools.copyFile(Val::Files.original_file, Val::Files.working_file)
-	if Val::Doc.filename_split == Val::Doc.filename_normalized
-		logger.info {"moved #{Val::Doc.filename_split} to tmpdir"}
-	else
-		logger.info {"renamed \"#{Val::Doc.filename_split}\" to \"#{Val::Doc.filename_normalized}\" and moved to tmpdir "}
-	end
+  # setting a var for the workingfile before its converted to .docx
+  doc_or_docx_workingfile = File.join(Val::Paths.tmp_dir, Val::Doc.filename_normalized)
+  #if its a .doc(x) lets go ahead and move it to tmpdir, keep a pristing copy in subfolder
+  FileUtils.mkdir_p Val::Paths.tmp_original_dir
+  Mcmlln::Tools.moveFile(Val::Doc.input_file_untag_chars, Val::Files.original_file)
+  # constructing 'working' destination since the new 'working' file might still be a .doc at this point
+  Mcmlln::Tools.copyFile(Val::Files.original_file, doc_or_docx_workingfile)
+  if Val::Doc.filename_split == Val::Doc.filename_normalized
+    logger.info {"moved #{Val::Doc.filename_split} to tmpdir"}
+  else
+    logger.info {"renamed \"#{Val::Doc.filename_split}\" to \"#{Val::Doc.filename_normalized}\" and moved to tmpdir "}
+  end
+  # if .doc, save up to .docx
+  if Val::Doc.extension == /.doc$/
+    logger.info {"working file is a .doc (#{Val::Doc.filename_normalized}), attempting to save as a .docx"}
+    convertDocToDocxPSscript(logger, doc_or_docx_workingfile)
+    if File.file?(Val::Files.working_file)
+      logger.info {".doc successfully saved as .docx (#{Val::Files.working_file})"}
+    else
+      logger.info {".doc NOT successfully saved as .docx :("}
+    end
+  end
 end
 
 #--------------------- RUN
@@ -79,25 +100,25 @@ set_submitter_info(logger,user_email,user_name,contacts_hash,status_hash)
 # ATTN: need to add a generic mailtxt for standalone validator
 #send email upon file receipt, different mails depending on whether drpobox api succeeded:
 unless File.file?(Val::Paths.testing_value_file)
-	if status_hash['api_ok'] && user_email =~ /@/
+  if status_hash['api_ok'] && user_email =~ /@/
     body = Val::Resources.mailtext_gsubs(file_recd_txt,'','','')
-		message = Vldtr::Mailtexts.generic(user_name,user_email,body) #or "#{body}" ?
-		Vldtr::Tools.sendmail("#{message}",user_email,'workflows@macmillan.com')
-	else
-		Vldtr::Tools.sendmail(Vldtr::Mailtexts.apifail(user_email),'workflows@macmillan.com','')
-	end
+    message = Vldtr::Mailtexts.generic(user_name,user_email,body) #or "#{body}" ?
+    Vldtr::Tools.sendmail("#{message}",user_email,'workflows@macmillan.com')
+  else
+    Vldtr::Tools.sendmail(Vldtr::Mailtexts.apifail(user_email),'workflows@macmillan.com','')
+  end
 end
 
-#test fileext for =~ .doc
+#test fileext for =~ .doc(x)
 if Val::Doc.extension !~ /.doc($|x$)/
-	nondoc(logger,status_hash)  #this is not renamed, and not moved until validator_cleanup
+  nondoc(logger,status_hash)  #this is not renamed, and not moved until validator_cleanup
 else
-	movedoc(logger)
-	logger.info {"running isbnsearch/password_check macro"}
-	status_hash['docisbn_string'] = Vldtr::Tools.run_macro(logger,macro_name) #run macro
-	status_hash['password_protected'] = Val::Hashes.isbn_hash['initialize']['password_protected']
-	if Val::Hashes.isbn_hash['completed'] == false then logger.info {"isbnsearch macro error!"} end
-	if status_hash['password_protected'] == true then logger.info {"document is password protected!"} end
+  movedoc(logger)
+  logger.info {"running isbnsearch/password_check macro"}
+  status_hash['docisbn_string'] = Vldtr::Tools.run_macro(logger,macro_name) #run macro
+  status_hash['password_protected'] = Val::Hashes.isbn_hash['initialize']['password_protected']
+  if Val::Hashes.isbn_hash['completed'] == false then logger.info {"isbnsearch macro error!"} end
+  if status_hash['password_protected'] == true then logger.info {"document is password protected!"} end
 end
 
 Vldtr::Tools.write_json(status_hash, Val::Files.status_file)

--- a/validator_tmparchive.rb
+++ b/validator_tmparchive.rb
@@ -52,13 +52,11 @@ def nondoc(logger,status_hash)
     f.puts "Unable to process \"#{Val::Doc.filename_normalized}\". Your document is not a .doc or .docx file."
   }
 end
-def convertDocToDocxPSscript(doc_or_docx_workingfile)
-  # doctodocx = "S:\\resources\\bookmaker_scripts\\bookmaker_addons\\htmlmaker_preprocessing.ps1"
-  # doctodocx = "#{Val::Paths.bookmaker_scripts_dir}\\bookmaker_addons\\htmlmaker_preprocessing.ps1"
-  # `PowerShell -NoProfile -ExecutionPolicy Bypass -Command "#{doctodocx} '#{doc_or_docx_workingfile}'"`
-  `#{Val::Resources.powershell_exe} "#{File.join(Val::Paths.scripts_dir, 'save_doc_as_docx.ps1')} '#{doc_or_docx_workingfile}'"`
+def convertDocToDocxPSscript(logger, doc_or_docx_workingfile)
+  saveas_output = ''
+  saveas_output = `#{Val::Resources.powershell_exe} "#{File.join(Val::Paths.scripts_dir, 'save_doc_as_docx.ps1')} '#{doc_or_docx_workingfile}'"`
 rescue => e
-  puts e
+  logger.info {"Error converting to .docx: #{e}\nOutput from .ps1: #{saveas_output}"}
 end
 def movedoc(logger)
   # setting a var for the workingfile before its converted to .docx
@@ -74,7 +72,7 @@ def movedoc(logger)
     logger.info {"renamed \"#{Val::Doc.filename_split}\" to \"#{Val::Doc.filename_normalized}\" and moved to tmpdir "}
   end
   # if .doc, save up to .docx
-  if Val::Doc.extension == /.doc$/
+  if Val::Doc.extension.match(/.doc$/)
     logger.info {"working file is a .doc (#{Val::Doc.filename_normalized}), attempting to save as a .docx"}
     convertDocToDocxPSscript(logger, doc_or_docx_workingfile)
     if File.file?(Val::Files.working_file)

--- a/validator_tmparchive.rb
+++ b/validator_tmparchive.rb
@@ -53,10 +53,9 @@ def nondoc(logger,status_hash)
   }
 end
 def convertDocToDocxPSscript(logger, doc_or_docx_workingfile)
-  saveas_output = ''
-  saveas_output = `#{Val::Resources.powershell_exe} "#{File.join(Val::Paths.scripts_dir, 'save_doc_as_docx.ps1')} '#{doc_or_docx_workingfile}'"`
+  `#{Val::Resources.powershell_exe} "#{File.join(Val::Paths.scripts_dir, 'save_doc_as_docx.ps1')} '#{doc_or_docx_workingfile}'"`
 rescue => e
-  logger.info {"Error converting to .docx: #{e}\nOutput from .ps1: #{saveas_output}"}
+  logger.info {"Error converting to .docx: #{e}"}
 end
 def movedoc(logger)
   # setting a var for the workingfile before its converted to .docx


### PR DESCRIPTION
This is to resolve: https://github.com/macmillanpublishers/bookmaker_validator/issues/92
I have tested it, seems to be working; saves the working file in the tmpdir up to a .docx if it's a .doc, acts on that and passes it to bookmaker; still returns the original .doc to the outbox.

@nelliemckesson, please review?