### PR TITLE
versatile block support for section_start_rules.js

### DIFF
--- a/validator_htmlconvert.rb
+++ b/validator_htmlconvert.rb
@@ -17,6 +17,8 @@ styles_json = File.join(htmlmakerjs_path, 'styles.json')
 
 stylefunctions_js = File.join(htmlmakerjs_path, 'style-functions.js')
 
+styleconfig_json = File.join(htmlmakerjs_path, 'style_config.json')
+
 status_hash = Val::Hashes.status_hash
 
 status_hash['html_conversion'] = ''
@@ -63,7 +65,7 @@ end
 
 if status_hash['html_conversion'] == true
   # Run our section start rules js on the html
-  node_output = localRunNode(section_start_rules_js, "#{Val::Files.html_output} #{Val::Files.section_start_rules_json}", status_hash)
+  node_output = localRunNode(section_start_rules_js, "#{Val::Files.html_output} #{Val::Files.section_start_rules_json} #{styleconfig_json}", status_hash)
   @logger.info {"output from running section_start_rules_js: \"#{node_output.split("\n").last}\""}
   # mark this as a success (true) or failure (false) in the status_hash
   if node_output.split("\n").last == "Content has been updated!"


### PR DESCRIPTION
For issue https://github.com/macmillanpublishers/bookmaker_validator/issues/104
@nelliemckesson, I am requesting a merge into the rulesjson branch: since you had said that the PR for that branch looked good except for needing additional commenting, I thought is might be easier for you to review the commenting there and then look at the changes here separately.  If you prefer to look at these updates merged into the rulesjson branch, feel free to merge in!  Whatever's easier for you:)

Here, I basically renamed and repurposed the evalOptionalHeaders method to include versatile block paras, and also stop evaluating matching paras that weren't the first member of a contiguous block; it was easiest to lump these things together.