### PR TITLE
removing err alert for html_conversion failure

### DIFF
--- a/validator_mailer.rb
+++ b/validator_mailer.rb
@@ -132,7 +132,7 @@ if nogoodisbn
 	errors = "#{errors}- #{nogoodisbn_msg}\n"
 	status_hash['status'] = 'isbn error'
 end
-if (!status_hash['validator_macro_complete'] || Val::Hashes.isbn_hash['completed'] == false || status_hash['html_conversion'] == false) && !nogoodisbn && status_hash['isbn_match_ok'] && status_hash['epub_format'] && status_hash['msword_copyedit']
+if (!status_hash['validator_macro_complete'] || Val::Hashes.isbn_hash['completed'] == false) && !nogoodisbn && status_hash['isbn_match_ok'] && status_hash['epub_format'] && status_hash['msword_copyedit']
 	validatorerr_msg=''; alert_hash['errors'].each {|h| h.each {|k,v| if v=='validator_error' then validatorerr_msg = h['message'].gsub(/PROJECT/,Val::Paths.project_name) end}}
 	errors = "#{errors}- #{validatorerr_msg}\n"
 	status_hash['status'] = 'validator error'


### PR DESCRIPTION
@nelliemckesson : So reverting the rulesjson merge pulled all the section_start_rules stuff out, but we had already merged in html_conversion in March.  Undoing this one line from that merge will allow the htmlconversion to succeed or fail silently, without trying to undo another merge from several weeks ago

FYI, the html conversion piece has not failed since we merged it in - I had added a parameter for the section_start rules into the same line, and it failed without cheerio.

I think I'll do some more refactoring around this as a build the bookmaker_connect script:)